### PR TITLE
Validate input while converting string to integer

### DIFF
--- a/contracts/utils/Bytes.sol
+++ b/contracts/utils/Bytes.sol
@@ -80,7 +80,11 @@ library Bytes {
         for (uint256 i = 0; i < b.length; i++) {
             uint256 val = uint256(uint8(b[i]));
             if (val >= 48 && val <= 57) {
+                // input is 0-9
                 result = result * 10 + (val - 48);
+            } else {
+                // invalid character, expecting integer input
+                revert("invalid input, only numbers allowed")
             }
         }
         return result;


### PR DESCRIPTION
While testing the deployment, one of my colleagues entered a negative number as the NFT id. 
To our suprise it got minted. As it turns out the toUint() function that converts strings to integer numbers silently ignores all non 0-9 characters:
toUint("123") = 123
toUint("-123") = 123
toUint("a1b2c3") = 123

This could be a potential security problem as different inputs will result in the same output. 
In my opinion aborting on invalid input would make more sense than ignoring non-number characters.