### PR TITLE
Add missing curly bracket.

### DIFF
--- a/scripts/mintfor.ts
+++ b/scripts/mintfor.ts
@@ -20,7 +20,7 @@ async function main() {
 }
 
 function getMintingBlob(tokenId: number, blueprint: string) {
-    return ethers.utils.toUtf8Bytes(`{${tokenId.toString()}}:{${blueprint}`);
+    return ethers.utils.toUtf8Bytes(`{${tokenId.toString()}}:{${blueprint}}`);
 }
 
 main()


### PR DESCRIPTION
Add missing curly bracket to `getMintingBlob` function to correctly conform to `{tokenId}:{blueprint}` format.