### PR TITLE
Add function to set the TokenURI

### DIFF
--- a/contracts/Asset.sol
+++ b/contracts/Asset.sol
@@ -5,6 +5,10 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "./Mintable.sol";
 
 contract Asset is ERC721, Mintable {
+
+    // Optional - used for L1-level late reveals, a static string can be used instead (check below)
+    string public baseTokenURI;
+    
     constructor(
         address _owner,
         string memory _name,
@@ -15,8 +19,22 @@ contract Asset is ERC721, Mintable {
     function _mintFor(
         address user,
         uint256 id,
-        bytes memory
+        bytes memory blueprint
     ) internal override {
         _safeMint(user, id);
+        // you may store the blueprint (on-chain metadata) here or implement some logic that relies on the blueprint data passed
+        // below is a bare-minimum implementation of a simple mapping, comment it out if you are not storing on-chain metadata
+        metadata[id] = blueprint;
+    }
+    
+    // overwrite OpenZeppelin's _baseURI to define the base for tokenURI
+    // can be a static value, use a variable if you want the ability to change this (L1 late-reveal)
+    function _baseURI() internal view override returns (string memory) {
+        return baseTokenURI;
+    }
+
+    // optional - change the baseTokenURI for late-reveal purposes
+    function setBaseTokenURI(string memory uri) public onlyOwner {
+        baseTokenURI = uri;
     }
 }


### PR DESCRIPTION
OpenSea requires the TokenURI to display metadata correctly in their marketplace. Including this function as a standard in our contract example will help minimise issues for customers who use this example contract to deploy a collection and need to add a TokenURI retrospectively.