### PR TITLE
[DXP-879] Upgrade ts-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ethereum-waffle": "^3.0.0",
     "ethers": "^5.0.0",
     "hardhat": "^2.4.1",
-    "ts-node": "^10.2.1",
+    "ts-node": "^10.8.1",
     "typechain": "^5.0.0"
   }
 }


### PR DESCRIPTION
When running `yarn hardhat run deploy/asset.ts --network ropsten`, getting the error:
```
Error: Debug Failure. False expression: Non-string value passed to ts.resolveTypeReferenceDirective, likely by a wrapping package working with an outdated resolveTypeReferenceDirectives signature.
```

Summarised testing steps and steps to reproduce [here](https://docs.google.com/document/d/1-c20rmOZKUWwsEDBtKTMzS7gUJHPtzU5W7044COoFrA/edit)

Issue created in Slack from a [message](https://imtbl.slack.com/archives/C0337K0U73K/p1655196623215349?thread_ts=1655196623.215349&cid=C0337K0U73K).

**Jira:** https://immutable.atlassian.net/browse/DXP-879