### PR TITLE
[DX-1183] Remove private key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,20 @@
+# # #
+# Update these IMX defaults before deployment
+# # #
 
-# Default values set by Immutable
-DEPLOYER_ROPSTEN_PRIVATE_KEY=5ca0dfa3f4f6a2be6468635cd42db296e202809557138a84f0954467c1248b66
-ALCHEMY_API_KEY=DvukuyBzEK-JyP6zp1NVeNVYLJCrzjp_
-
-# Update these before deployment
-ETHERSCAN_API_KEY=
+# private key for the production network 
 DEPLOYER_MAINNET_PRIVATE_KEY=
+# private key for non-production networks
+DEPLOYER_TESTNET_PRIVATE_KEY=
 
+# provider API keys
+ALCHEMY_MAINNET_API_KEY=
+ALCHEMY_ROPSTEN_API_KEY=DvukuyBzEK-JyP6zp1NVeNVYLJCrzjp_
+ALCHEMY_GOERLI_API_KEY=WmzAboIrYGOEDnuUJnxQ8ucuu3jfoR_q
+ETHERSCAN_API_KEY=
 
 # The address of the owner of the contract
-CONTRACT_OWNER_ADDRESS=0x75965652aC872E3A9fd3c9ad8E290473c23d763c
+CONTRACT_OWNER_ADDRESS=address_of_the_private_key
 # The name of the contract (e.g. 'Gods Unchained Cards')
 CONTRACT_NAME="Gods Unchained Cards"
 # The 'symbol' of the contract (a short-form representation e.g. 'GODS')

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,15 +14,15 @@ module.exports = {
   solidity: "0.8.4",
   networks: {
     dev: {
-      url: `https://eth-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-      accounts: [`0x${process.env.DEPLOYER_ROPSTEN_PRIVATE_KEY}`],
+      url: `https://eth-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_GOERLI_API_KEY}`,
+      accounts: [`0x${process.env.DEPLOYER_TESTNET_PRIVATE_KEY}`],
     },
     ropsten: {
-      url: `https://eth-ropsten.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
-      accounts: [`0x${process.env.DEPLOYER_ROPSTEN_PRIVATE_KEY}`],
+      url: `https://eth-ropsten.alchemyapi.io/v2/${process.env.ALCHEMY_ROPSTEN_API_KEY}`,
+      accounts: [`0x${process.env.DEPLOYER_TESTNET_PRIVATE_KEY}`],
     },
     mainnet: {
-      url: `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
+      url: `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_MAINNET_API_KEY}`,
       accounts: [`0x${process.env.DEPLOYER_MAINNET_PRIVATE_KEY}`],
     },
   },


### PR DESCRIPTION
https://immutable.atlassian.net/browse/DX-1183

The `.env.example` file contained a private key used to deploy non-prod contracts (note this is a public repo!). It has been moved out of the repo into 1Password.

Refactored the config to handle multiple test networks.   