### PR TITLE
Update Mintable.sol to prevent Owner from calling MintFor()

### DIFF
--- a/contracts/Mintable.sol
+++ b/contracts/Mintable.sol
@@ -18,7 +18,7 @@ abstract contract Mintable is Ownable, IMintable {
     }
 
     modifier onlyOwnerOrIMX() {
-        require(msg.sender == imx || msg.sender == owner(), "Function can only be called by owner or IMX");
+        require(msg.sender == imx, "Function can only be called by IMX");
         _;
     }
 


### PR DESCRIPTION
Remove ability for owner to call mintFor() to prevent potential issues with Owner directly calling function and then having conflicts with IMX APIs